### PR TITLE
Adding fix for issue calculating stockpile size before item is first assigned

### DIFF
--- a/src/main/kotlin/me/branchpanic/mods/stockpile/content/blockentity/ItemBarrelBlockEntity.kt
+++ b/src/main/kotlin/me/branchpanic/mods/stockpile/content/blockentity/ItemBarrelBlockEntity.kt
@@ -176,7 +176,9 @@ class ItemBarrelBlockEntity(
         if (item.isEmpty) {
             storage.contents = ItemStackQuantifier.NONE
         } else {
-            val itemAmount = min(max(0L, getLong(AMOUNT_STORED_TAG)), storage.capacity)
+            val itemAmount = min(
+                max(0L, getLong(AMOUNT_STORED_TAG)),
+                (item.maxCount * (storage as MassItemStackStorage).maxStacks).toLong())
             storage.contents = ItemStackQuantifier(item.withCount(1), itemAmount)
         }
     }


### PR DESCRIPTION
When an barrel is first read from a tag there is an issue where the max capacity can be miscalculated due to the maxCount for the barrel using 16 (the maxCount of the default air item) this can result in a barrel being reset down to a max size of (max Stacks *16) even if it was supposed to be a 64 stack type item. This resulted in many lost items every time the client signed into a server.